### PR TITLE
casefold headers + reject empty data with whitespace

### DIFF
--- a/src/monalisten/_core.py
+++ b/src/monalisten/_core.py
@@ -87,9 +87,8 @@ class Monalisten:
         return {k.casefold(): v for k, v in event.json().items()}
 
     async def _handle_event(self, event: ServerSentEvent) -> None:
-        if event.data == "{}":
+        if not (event_data := self._prepare_event_data(event)):
             return
-        event_data = self._prepare_event_data(event)
 
         if not self._passes_auth(event_data):
             return

--- a/src/monalisten/_core.py
+++ b/src/monalisten/_core.py
@@ -83,19 +83,22 @@ class Monalisten:
 
         return wrapper
 
+    def _prepare_event_data(self, event: ServerSentEvent) -> dict[str, Any]:
+        return {k.casefold(): v for k, v in event.json().items()}
+
     async def _handle_event(self, event: ServerSentEvent) -> None:
         if event.data == "{}":
             return
-        data = event.json()
+        event_data = self._prepare_event_data(event)
 
-        if not self._passes_auth(data):
+        if not self._passes_auth(event_data):
             return
 
-        if not (event_name := data.get(EVENT_HEADER)):
+        if not (event_name := event_data.get(EVENT_HEADER)):
             msg = f"received data is missing the {EVENT_HEADER} header"
             raise MonalistenError(msg)
 
-        if not (body := data.get("body")):
+        if not (body := event_data.get("body")):
             msg = "received data doesn't contain a body"
             raise MonalistenError(msg)
 

--- a/tests/ghk_utils.py
+++ b/tests/ghk_utils.py
@@ -68,12 +68,12 @@ DUMMY_REPO = Repository(
 ).model_dump(mode="json", exclude_unset=True)  # fmt: skip
 
 DUMMY_AUTH_EVENT = {
-    "x-github-event": "github_app_authorization",
+    "X-GitHub-Event": "github_app_authorization",
     "body": {"action": "revoked", "sender": DUMMY_USER},
 }
 
 DUMMY_STAR_EVENT = {
-    "x-github-event": "star",
+    "X-GitHub-Event": "star",
     "body": {
         "action": "created",
         "repository": DUMMY_REPO,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -47,6 +47,7 @@ async def test_no_token(sse_server: tuple[ServerQueue, str]) -> None:
             False,
         ),
         ({SIG_HEADER: sign_auth_event("foobar")}, nullcontext(), True),
+        ({SIG_HEADER.title(): sign_auth_event("foobar")}, nullcontext(), True),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -33,3 +33,16 @@ async def test_core_streaming(sse_server: tuple[ServerQueue, str]) -> None:
     assert all(e.event == "message" for e in received_events)
     assert received_events[0].data == "{}"
     assert received_events[1].data == '{"foo":"bar"}'
+
+
+@pytest.mark.parametrize("event_data", ["{}", "{ }"])
+@pytest.mark.asyncio
+async def test_ignore_no_data(
+    sse_server: tuple[ServerQueue, str], event_data: str
+) -> None:
+    queue, url = sse_server
+    await queue._queue.put(event_data)
+    await queue.end_signal()
+
+    client = Monalisten(url)
+    await client.listen()


### PR DESCRIPTION
This fixes two issues caused by strict assumptions during event data processing:
1. smee.io sends events with the headers casefolded (e.g. `x-github-event`) and the library was built based on that assumption. Other services, however, may send them in title case (so `X-GitHub-Event`), which would lead a Monalisten client to think the event didn't have an event header at all.
2. Monalisten doesn't attempt to process events with empty data. However, it only rejected events that had their event string be exactly `{}`, so it would process `{ }`, even though it also is empty.