### PR TITLE
test: use already installed anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,15 @@ repository = "https://github.com/trag1c/monalisten"
 [dependency-groups]
 dev = [
   "aiohttp==3.12.15",
-  "pyright==1.1.403",
+  "anyio==4.11.0",
+  "pyright==1.1.405",
   "pytest==8.4.1",
-  "pytest-asyncio==1.1.0",
   "ruff==0.12.9",
   "taplo==0.9.3",
 ]
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
+anyio_mode = "auto"
 
 [tool.ruff]
 target-version = "py39"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@ async def sse_server() -> AsyncIterator[tuple[ServerQueue, str]]:
     app, runner, port = await start_test_server()
     yield ServerQueue(app[QUEUE_KEY]), f"http://127.0.0.1:{port}/events"
     await runner.cleanup()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from .sse_server import ServerQueue
 
 
-@pytest.mark.asyncio
 async def test_no_token(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_AUTH_EVENT)
@@ -50,7 +49,6 @@ async def test_no_token(sse_server: tuple[ServerQueue, str]) -> None:
         ({SIG_HEADER.title(): sign_auth_event("foobar")}, [], True),
     ],
 )
-@pytest.mark.asyncio
 async def test_validation(
     sse_server: tuple[ServerQueue, str],
     sig_header_entry: dict[str, str],
@@ -82,7 +80,6 @@ async def test_validation(
 
 # Covers a prior case where a payload with `x-github-event` and `x-hub-signature-256`
 # headers but no `body` would crash the authentication check if a token was set.
-@pytest.mark.asyncio
 async def test_no_eager_body_access(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event({SIG_HEADER: "foo", EVENT_HEADER: "bar"})

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING
 
-import pytest
-
 from monalisten import Monalisten, events
 from tests.ghk_utils import DUMMY_AUTH_EVENT, DUMMY_STAR_EVENT
 
@@ -12,7 +10,6 @@ if TYPE_CHECKING:
     from .sse_server import ServerQueue
 
 
-@pytest.mark.asyncio
 async def test_regular_scenario(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_AUTH_EVENT)
@@ -35,7 +32,6 @@ async def test_regular_scenario(sse_server: tuple[ServerQueue, str]) -> None:
     assert all(hooks_triggered)
 
 
-@pytest.mark.asyncio
 async def test_one_event_multiple_hooks(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_STAR_EVENT)
@@ -57,7 +53,6 @@ async def test_one_event_multiple_hooks(sse_server: tuple[ServerQueue, str]) -> 
     assert all(hooks_triggered)
 
 
-@pytest.mark.asyncio
 async def test_multiple_events_one_hook(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_STAR_EVENT)
@@ -78,7 +73,6 @@ async def test_multiple_events_one_hook(sse_server: tuple[ServerQueue, str]) -> 
     assert trigger_count == 2
 
 
-@pytest.mark.asyncio
 async def test_wildcard_hook(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_STAR_EVENT)
@@ -100,7 +94,6 @@ async def test_wildcard_hook(sse_server: tuple[ServerQueue, str]) -> None:
     assert trigger_count == 4
 
 
-@pytest.mark.asyncio
 async def test_subhooks(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     dummy_star_delete_event = copy.deepcopy(DUMMY_STAR_EVENT)

--- a/tests/test_meta_hooks.py
+++ b/tests/test_meta_hooks.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from .sse_server import ServerQueue
 
 
-@pytest.mark.asyncio
 async def test_on_ready(
     sse_server: tuple[ServerQueue, str], capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -40,7 +39,6 @@ async def test_on_ready(
     assert sorted(printed_messages) == ["hello", "there"]
 
 
-@pytest.mark.asyncio
 async def test_on_auth_issue(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event(DUMMY_AUTH_EVENT)
@@ -70,7 +68,6 @@ async def test_on_auth_issue(sse_server: tuple[ServerQueue, str]) -> None:
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_no_error_hook(
     sse_server: tuple[ServerQueue, str], event: dict[str, Any], err_msg: str
 ) -> None:
@@ -95,7 +92,6 @@ async def test_no_error_hook(
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_on_error_preprocessing(
     sse_server: tuple[ServerQueue, str], event: dict[str, Any], err_msg: str
 ) -> None:
@@ -114,7 +110,6 @@ async def test_on_error_preprocessing(
     await client.listen()
 
 
-@pytest.mark.asyncio
 async def test_handling_pydantic_errors(
     sse_server: tuple[ServerQueue, str],
     capsys: pytest.CaptureFixture[str],
@@ -151,7 +146,6 @@ async def test_handling_pydantic_errors(
     )
 
 
-@pytest.mark.asyncio
 async def test_on_error_processing(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event({EVENT_HEADER: "bar", "body": {"foo": "bar"}})
@@ -185,7 +179,6 @@ async def test_on_error_processing(sse_server: tuple[ServerQueue, str]) -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_on_error_self_loop(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.end_signal()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from .sse_server import ServerQueue
 
 
-@pytest.mark.asyncio
 async def test_core_streaming(sse_server: tuple[ServerQueue, str]) -> None:
     queue, url = sse_server
     await queue.send_event({})
@@ -36,7 +35,6 @@ async def test_core_streaming(sse_server: tuple[ServerQueue, str]) -> None:
 
 
 @pytest.mark.parametrize("payload", ["{}", "{ }"])
-@pytest.mark.asyncio
 async def test_ignore_no_data(
     sse_server: tuple[ServerQueue, str], payload: str
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -146,9 +146,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
 ]
 
 [[package]]
@@ -167,15 +167,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -424,9 +415,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp" },
+    { name = "anyio" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "taplo" },
 ]
@@ -441,9 +432,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = "==3.12.15" },
-    { name = "pyright", specifier = "==1.1.403" },
+    { name = "anyio", specifier = "==4.11.0" },
+    { name = "pyright", specifier = "==1.1.405" },
     { name = "pytest", specifier = "==8.4.1" },
-    { name = "pytest-asyncio", specifier = "==1.1.0" },
     { name = "ruff", specifier = "==0.12.9" },
     { name = "taplo", specifier = "==0.9.3" },
 ]
@@ -835,15 +826,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.403"
+version = "1.1.405"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/6c/ba4bbee22e76af700ea593a1d8701e3225080956753bee9750dcc25e2649/pyright-1.1.405.tar.gz", hash = "sha256:5c2a30e1037af27eb463a1cc0b9f6d65fec48478ccf092c1ac28385a15c55763", size = 4068319, upload-time = "2025-09-04T03:37:06.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/524f832e1ff1962a22a1accc775ca7b143ba2e9f5924bb6749dce566784a/pyright-1.1.405-py3-none-any.whl", hash = "sha256:a2cb13700b5508ce8e5d4546034cb7ea4aedb60215c6c33f56cec7f53996035a", size = 5905038, upload-time = "2025-09-04T03:37:04.913Z" },
 ]
 
 [[package]]
@@ -862,20 +853,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Inspired by https://github.com/ghostty-org/discord-bot/pull/377

`githubkit` already defines `anyio` as a dependency. So there is no need to _also_ have the `pytest-asyncio` plugin. We can simplify dependencies by removing this.