### PR TITLE
skip event parsing when no hooks are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.3.1] - 2025-10-20
+
+### Changed
+- Received event payload bodies will no longer be parsed if the event doesn't
+  define any hooks
+
+
 ## [v0.3.0] - 2025-09-19
 
 ### Added
@@ -65,3 +72,4 @@ Initial release 🎉
 [v0.1.1]: https://github.com/trag1c/monalisten/compare/v0.1.0...v0.1.1
 [v0.2.0]: https://github.com/trag1c/monalisten/compare/v0.1.1...v0.2.0
 [v0.3.0]: https://github.com/trag1c/monalisten/compare/v0.2.0...v0.3.0
+[v0.3.1]: https://github.com/trag1c/monalisten/compare/v0.3.0...v0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "monalisten"
-version = "0.3.0"
+version = "0.3.1"
 description = "Monalisten is an async library for handling GitHub webhook events in an easy way"
 readme = "README.md"
 license = "MIT"

--- a/src/monalisten/_core.py
+++ b/src/monalisten/_core.py
@@ -122,6 +122,12 @@ class Monalisten:
         if not await self._passes_auth(payload):
             return
 
+        hook_kinds = [self.event.any["*"], self.event[event_name]["*"]]
+        if action := body.get("action"):
+            hook_kinds.append(self.event[event_name][action])
+        if not (hooks := list(chain.from_iterable(hook_kinds))):
+            return  # Skip parsing an event
+
         try:
             webhook_event = webhooks.parse_obj(event_name, body)
         except ValidationError as pydantic_exc:
@@ -131,12 +137,7 @@ class Monalisten:
             await self._raise(exc, payload, event_name)
             return
 
-        hook_kinds = [self.event.any["*"], self.event[event_name]["*"]]
-        if action := body.get("action"):
-            hook_kinds.append(self.event[event_name][action])
-        await self._dispatch_hooks(
-            payload, event_name, chain.from_iterable(hook_kinds), webhook_event
-        )
+        await self._dispatch_hooks(payload, event_name, hooks, webhook_event)
 
     async def listen(self) -> None:
         """Start an internal HTTP client and stream events from `source`."""

--- a/tests/test_meta_hooks.py
+++ b/tests/test_meta_hooks.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from pydantic import ValidationError
 
-from monalisten import AuthIssue, Error, Monalisten, MonalistenPreprocessingError
+from monalisten import (
+    AuthIssue,
+    Error,
+    Monalisten,
+    MonalistenPreprocessingError,
+    events,
+)
 from monalisten._core import EVENT_HEADER, SIG_HEADER
 from tests.ghk_utils import DUMMY_AUTH_EVENT, sign_auth_event
 
@@ -62,10 +68,6 @@ async def test_on_auth_issue(sse_server: tuple[ServerQueue, str]) -> None:
     [
         ({"foo": "bar"}, f"received data is missing the {EVENT_HEADER} header"),
         ({EVENT_HEADER: "push"}, "received data doesn't contain a body"),
-        (
-            {EVENT_HEADER: "push", "body": {"foo": "bar"}},
-            "the received payload could not be parsed as an event",
-        ),
     ],
 )
 async def test_no_error_hook(
@@ -78,6 +80,38 @@ async def test_no_error_hook(
     client = Monalisten(url)
 
     with pytest.raises(MonalistenPreprocessingError, match=err_msg):
+        await client.listen()
+
+
+async def test_no_error_hook_no_preprocessing_trigger_on_unused_event(
+    sse_server: tuple[ServerQueue, str],
+) -> None:
+    queue, url = sse_server
+    await queue.send_event({EVENT_HEADER: "push", "body": {"foo": "bar"}})
+    await queue.end_signal()
+
+    client = Monalisten(url)
+
+    await client.listen()
+
+
+async def test_no_error_hook_preprocessing_trigger_on_used_event(
+    sse_server: tuple[ServerQueue, str],
+) -> None:
+    queue, url = sse_server
+    await queue.send_event({EVENT_HEADER: "push", "body": {"foo": "bar"}})
+    await queue.end_signal()
+
+    client = Monalisten(url)
+
+    @client.event.push
+    async def _(_: events.Push) -> None:
+        pass
+
+    with pytest.raises(
+        MonalistenPreprocessingError,
+        match="the received payload could not be parsed as an event",
+    ):
         await client.listen()
 
 
@@ -123,6 +157,10 @@ async def test_handling_pydantic_errors(
     await queue.end_signal()
 
     client = Monalisten(url)
+
+    @client.event.github_app_authorization
+    async def _(_: events.GithubAppAuthorization) -> None:
+        pass
 
     @client.internal.error
     async def _(error: Error) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "monalisten"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "githubkit" },


### PR DESCRIPTION
Reduces compute waste :)

What prompted me to make this change is that Ghostty Bot would sometimes trigger a Sentry error because due to Monalisten (well, githubkit (well, pydantic)) failing to parse payloads for incorrectly sent events that we don't even use (e.g. `workflow_job`).